### PR TITLE
21 anpassen der spawnmonster klasse

### DIFF
--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -48,6 +48,7 @@ public class GameHandler implements WebSocketHandler {
         handlers.put("REQUEST_USERNAMES", new RequestUsernamesHandler());
         handlers.put("SPAWN_MONSTER", new SpawnMonsterHandler(new SecureRandom()));
         handlers.put("PLAYER_ROLL_DICE", new PlayerRollsDiceHandler());
+        handlers.put("ROUND_COUNTER", new GameRoundHandler());
     }
 
     public static GameHandler getInstance(){

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -49,6 +49,7 @@ public class GameHandler implements WebSocketHandler {
         handlers.put("SPAWN_MONSTER", new SpawnMonsterHandler(new SecureRandom()));
         handlers.put("PLAYER_ROLL_DICE", new PlayerRollsDiceHandler());
         handlers.put("ROUND_COUNTER", new GameRoundHandler());
+        handlers.put("END_TURN", new TurnHandler());
         handlers.put("REQUEST_USERNAMES_SWITCH", new RequestUsernamesForSwitchHandler());
     }
 

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -25,7 +25,6 @@ import static at.aau.se2.utils.UtilityMethods.findPlayer;
 public class GameHandler implements WebSocketHandler {
     private final Logger logger;
     private static GameHandler GAMEHANDLER;
-    private final Map<String, WebSocketSession> sessions = new HashMap<>();
     private final Map<String, ActionHandler> handlers = new HashMap<>();
     private final List<WebSocketSession> connectionOrder = new ArrayList<>();
     private final static List<Player> players = new ArrayList<>();

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -41,6 +41,7 @@ public class GameHandler implements WebSocketHandler {
         handlers.put("MONSTER_ATTACK", new MonsterAttackHandler());
         handlers.put("REGISTER_USERNAME", new RegisterUsernameHandler());
         handlers.put("REQUEST_USERNAMES", new RequestUsernamesHandler());
+        handlers.put("SPAWN_MONSTER", new SpawnMonsterHandler());
     }
 
     public static GameHandler getInstance(){

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -47,6 +47,7 @@ public class GameHandler implements WebSocketHandler {
         handlers.put("REGISTER_USERNAME", new RegisterUsernameHandler());
         handlers.put("REQUEST_USERNAMES", new RequestUsernamesHandler());
         handlers.put("SPAWN_MONSTER", new SpawnMonsterHandler(new SecureRandom()));
+        handlers.put("PLAYER_ROLL_DICE", new PlayerRollsDiceHandler());
     }
 
     public static GameHandler getInstance(){

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -8,6 +8,7 @@ import at.aau.se2.utils.UtilityMethods;
 import at.aau.se2.handler.game.subhandlers.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import org.springframework.web.socket.*;
 
@@ -69,7 +70,7 @@ public class GameHandler implements WebSocketHandler {
             }
         }
         else {
-            session.sendMessage(new TextMessage("Waiting for other players to connect."));
+           sendMessage(session, "WAITING_FOR_PLAYERS", "Waiting for other players to connect.");
         }
     }
 
@@ -110,7 +111,7 @@ public class GameHandler implements WebSocketHandler {
             for(Player player : lobby.getPlayers()){
                 connectionOrder.remove(player.getSession());
                 setNextPlayer(-1);
-                player.getSession().sendMessage(new TextMessage("The game has finished, you will be disconnected"));
+                sendMessage(player.getSession(), "GAME_FINISHED", "The game has finished, you will be disconnected");
                 player.getSession().close();
 
                 players.remove(player);
@@ -131,7 +132,7 @@ public class GameHandler implements WebSocketHandler {
             }
         }
         else
-            session.sendMessage(new TextMessage("GameStatus Update nicht möglich"));
+            sendMessage(session, "ERROR_GAMESTATUS", "GameStatus Update nicht möglich");
     }
 
     public Lobby createLobby(){
@@ -144,4 +145,15 @@ public class GameHandler implements WebSocketHandler {
         lobby.getPlayers().add(player);
         session.sendMessage(new TextMessage("{ 'type':'LOBBY_ASSIGNED' }"));
     }
+
+    private void sendMessage(WebSocketSession session, String type, String content) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode messageNode = mapper.createObjectNode();
+        messageNode.put("type", type);
+        messageNode.put("content", content);
+        session.sendMessage(new TextMessage(messageNode.toString()));
+    }
+
+
+
 }

--- a/src/main/java/at/aau/se2/handler/game/GameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/GameHandler.java
@@ -38,8 +38,8 @@ public class GameHandler implements WebSocketHandler {
 
     private GameHandler(){
         logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-        handlers.put("DRAW_CARD", new DrawCardHandler());
-        handlers.put("SWITCH_CARD_DECK", new SwitchCardDeckHandler());
+        handlers.put("DRAW_CARD", new DrawCardHandler(new SecureRandom()));
+        handlers.put("SWITCH_CARD_DECK", new SwitchCardDeckHandler(new SecureRandom()));
         handlers.put("SWITCH_CARD_PLAYER", new SwitchCardPlayerHandler());
         handlers.put("PLAYER_ATTACK", new PlayerAttackHandler());
         handlers.put("MONSTER_ATTACK", new MonsterAttackHandler());

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/DrawCardHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/DrawCardHandler.java
@@ -1,9 +1,7 @@
 package at.aau.se2.handler.game.subhandlers;
 
 import at.aau.se2.exceptions.PlayerNotFoundException;
-import at.aau.se2.handler.game.GameHandler;
 import at.aau.se2.utils.Lobby;
-import at.aau.se2.utils.Player;
 import at.aau.se2.utils.UtilityMethods;
 import at.aau.se2.model.Actioncard;
 import at.aau.se2.model.characters.Archer;

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/DrawCardHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/DrawCardHandler.java
@@ -21,7 +21,11 @@ import java.util.logging.Logger;
 public class DrawCardHandler implements ActionHandler {
     private WebSocketSession session;
     private static int cardId = 0;
+    private SecureRandom rn;
 
+    public DrawCardHandler(SecureRandom rn){
+        this.rn = rn;
+    }
     @Override
     public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby){
         // generate a new card and send it to client
@@ -47,7 +51,6 @@ public class DrawCardHandler implements ActionHandler {
     }
 
     public Actioncard drawRandomCard(Lobby lobby){
-        SecureRandom rn = new SecureRandom();
         int i = lobby.getGameState().getIndexMinimumCardAmount();
         Actioncard card = switch(i){
             case 0 -> new Archer(rn.nextInt(1,4), cardId++);

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/GameRoundHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/GameRoundHandler.java
@@ -1,0 +1,58 @@
+package at.aau.se2.handler.game.subhandlers;
+
+
+import at.aau.se2.utils.Lobby;
+import at.aau.se2.utils.Player;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class GameRoundHandler implements ActionHandler {
+    private static final Logger logger = Logger.getLogger(GameRoundHandler.class.getName());
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private int roundNumber = 0;
+
+
+    @Override
+    public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
+        try {
+            String type = msg.path("type").asText();
+            if ("ROUND_COUNTER".equals(type)) {
+                endRound(lobby);
+                startNextRound(lobby);
+            }
+        } catch (Exception e) {
+            logger.severe("An error occurred during round handling: " + e.getMessage());
+        }
+    }
+
+    private void endRound(Lobby lobby) {
+        logger.info("Ending round " + roundNumber);
+    }
+
+    private void startNextRound(Lobby lobby) {
+        roundNumber++;
+        for (Player player : lobby.getPlayers()) {
+            sendStartRoundMessage(player.getSession());
+        }
+        logger.info("Starting round " + roundNumber);
+    }
+
+    private void sendStartRoundMessage(WebSocketSession session) {
+        ObjectNode messageNode = objectMapper.createObjectNode();
+        String roundMessage = String.valueOf(roundNumber);
+        messageNode.put("type", "ROUND_COUNTER");
+        messageNode.put("round", roundMessage);
+        try {
+            session.sendMessage(new TextMessage(messageNode.toString()));
+        } catch (IOException e) {
+            logger.severe("Failed to send start round message: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/PlayerRollsDiceHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/PlayerRollsDiceHandler.java
@@ -1,0 +1,60 @@
+package at.aau.se2.handler.game.subhandlers;
+
+
+import at.aau.se2.handler.game.GameHandler;
+import at.aau.se2.utils.Lobby;
+import at.aau.se2.utils.Player;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import java.util.List;
+import java.util.logging.Logger;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+
+
+
+public class PlayerRollsDiceHandler implements ActionHandler {
+    private static final Logger logger = Logger.getLogger(PlayerRollsDiceHandler.class.getName());
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
+        try {
+            Player playerToRoll = selectPlayerToRoll(lobby);
+            if (playerToRoll != null) {
+                String username = GameHandler.getUsernames().get(0);
+                sendDiceRollRequest(playerToRoll.getSession(), username);
+                movePlayerToEndOfQueue(lobby, playerToRoll);
+            }
+        }
+        catch (Exception e){
+            logger.warning("No players available to roll the dice.");
+        }
+    }
+
+
+    private Player selectPlayerToRoll(Lobby lobby) {
+        List<Player> players = lobby.getPlayers();
+        return !players.isEmpty() ? players.get(0) : null;
+    }
+
+    private void movePlayerToEndOfQueue(Lobby lobby, Player player) {
+        List<Player> players = lobby.getPlayers();
+        if (players.remove(player)) {
+            players.add(player);
+        }
+    }
+
+    private void sendDiceRollRequest(WebSocketSession session, String username) {
+        ObjectNode messageNode = objectMapper.createObjectNode();
+        messageNode.put("type", "REQUEST_ROLL");
+        messageNode.put("username", username);
+        try {
+            session.sendMessage(new TextMessage(messageNode.toString()));
+        } catch (IOException e) {
+            logger.severe("Failed to send dice roll request: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/RegisterUsernameHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/RegisterUsernameHandler.java
@@ -24,7 +24,7 @@ public class RegisterUsernameHandler implements ActionHandler{
            for(Player a:players){
                if(a.getSession()==session){
                    System.out.println("Username wurde zum Player hinzugefügt");
-                   a.setusername(username);
+                   a.setUsername(username);
                }
             }
 

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/RequestUsernamesForSwitchHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/RequestUsernamesForSwitchHandler.java
@@ -3,7 +3,6 @@ package at.aau.se2.handler.game.subhandlers;
 import at.aau.se2.handler.game.GameHandler;
 import at.aau.se2.utils.Lobby;
 import at.aau.se2.utils.Player;
-import at.aau.se2.utils.UtilityMethods;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -15,7 +14,7 @@ import java.util.logging.Logger;
 
 public class RequestUsernamesForSwitchHandler extends RequestUsernamesHandler{
 
-    ArrayList<String> usernames = new ArrayList<String>();
+    ArrayList<String> usernames = new ArrayList<>();
     @Override
     public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
         try{

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
@@ -36,7 +36,7 @@ public class SpawnMonsterHandler implements ActionHandler {
         }
     }
 
-    private Monster spawnRandomMonster(int zone,Lobby lobby){
+    public Monster spawnRandomMonster(int zone,Lobby lobby){
         int monstertype = rn.nextInt(1,3);
 
         Monster monster = switch(monstertype){

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
@@ -40,9 +40,9 @@ public class SpawnMonsterHandler implements ActionHandler {
         int monstertype = rn.nextInt(1,3);
 
         Monster monster = switch(monstertype){
-            case 1 -> new Slime(zone, 0, monsterId++);
-            case 2 -> new Sphinx(zone, 0, monsterId++);
-            default -> new Bullrog(zone, 0, monsterId++);
+            case 1 -> new Slime(zone, 0, monsterId);
+            case 2 -> new Sphinx(zone, 0, monsterId);
+            default -> new Bullrog(zone, 0, monsterId);
         };
         increaseMonsterId();
         lobby.getGameState().getMonsters().add(monster);

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
@@ -1,12 +1,51 @@
 package at.aau.se2.handler.game.subhandlers;
 
+import at.aau.se2.model.Monster;
+import at.aau.se2.model.monsters.Bullrog;
+import at.aau.se2.model.monsters.Slime;
+import at.aau.se2.model.monsters.Sphinx;
 import at.aau.se2.utils.Lobby;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import java.security.SecureRandom;
+import java.util.logging.Logger;
 
-public class SpawnMonsterHandler implements ActionHandler{
+
+
+public class SpawnMonsterHandler implements ActionHandler {
+    private final SecureRandom rn;
+    public static int monsterId = 0;
+
+    public SpawnMonsterHandler(){
+        rn = new SecureRandom();
+    }
     @Override
     public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
+        try {
+            int zone = msg.path("zone").asInt();
+            Logger.getLogger("global").info("Received zone: " + zone);
+            Monster monster = spawnRandomMonster(zone,lobby);
+            session.sendMessage(new TextMessage(convertToJson(monster)));
+        }catch (Exception e){
+            Logger.getLogger("global")
+                    .info("SPAWN_MONSTER: " + e.getMessage());
+        }
+    }
 
+    private Monster spawnRandomMonster(int zone,Lobby lobby){
+        int monstertype = rn.nextInt(1,3);
+
+        Monster monster = switch(monstertype){
+            case 1 -> new Slime(zone, 0, monsterId++);
+            case 2 -> new Sphinx(zone, 0, monsterId++);
+            default -> new Bullrog(zone, 0, monsterId++);
+        };
+        lobby.getGameState().getMonsters().add(monster);
+        return monster;
+    }
+
+    public String convertToJson(Monster monster) {
+        return "{ 'type':'SPAWN_MONSTER', 'monster': " + monster.convertToJson() + "}";
     }
 }

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandler.java
@@ -5,6 +5,7 @@ import at.aau.se2.model.monsters.Bullrog;
 import at.aau.se2.model.monsters.Slime;
 import at.aau.se2.model.monsters.Sphinx;
 import at.aau.se2.utils.Lobby;
+import at.aau.se2.utils.Player;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 import org.springframework.web.socket.TextMessage;
@@ -28,11 +29,17 @@ public class SpawnMonsterHandler implements ActionHandler {
         try {
             int zone = msg.path("zone").asInt();
             Logger.getLogger("global").info("Received zone: " + zone);
-            Monster monster = spawnRandomMonster(zone,lobby);
-            session.sendMessage(new TextMessage(convertToJson(monster)));
-        }catch (Exception e){
-            Logger.getLogger("global")
-                    .info("SPAWN_MONSTER: " + e.getMessage());
+            Monster monster = spawnRandomMonster(zone, lobby);
+
+            String monsterJson = convertToJson(monster);
+
+            for (Player player : lobby.getPlayers()) {
+                if (player.getSession().isOpen()) {
+                    player.getSession().sendMessage(new TextMessage(monsterJson));
+                }
+            }
+        } catch (Exception e) {
+            Logger.getLogger("global").info("SPAWN_MONSTER: " + e.getMessage());
         }
     }
 
@@ -48,6 +55,7 @@ public class SpawnMonsterHandler implements ActionHandler {
         lobby.getGameState().getMonsters().add(monster);
         return monster;
     }
+
 
 
     public String convertToJson(Monster monster) {

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandler.java
@@ -19,7 +19,6 @@ public class SwitchCardDeckHandler extends DrawCardHandler implements ActionHand
             String[] infos = readInfosFromMessage(msg);
             List<Actioncard> cards = UtilityMethods.findPlayer(session, lobby).getCards();
             Actioncard newCard = drawRandomCard(lobby);
-            String test = infos[1];
             System.out.println("Test in der handlemessage"+infos[1]);
             for(Actioncard c : cards){
                 if(c.getId() == Integer.parseInt(infos[1])){

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandler.java
@@ -9,10 +9,16 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.logging.Logger;
 
 public class SwitchCardDeckHandler extends DrawCardHandler implements ActionHandler {
+
+    public SwitchCardDeckHandler(SecureRandom rn){
+        super(rn);
+    }
+
     @Override
     public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby){
         try {

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
@@ -27,9 +27,6 @@ public class SwitchCardPlayerHandler implements ActionHandler {
             List<Actioncard> cards = UtilityMethods.findPlayer(session, lobby).getCards();
             Actioncard currentcard = null;
 
-
-
-            // TODO: karte aus handkarten von spieler entfernen
             int cardid=getidofcard(textfrommessage);
 
             for(Actioncard c : cards){

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
@@ -81,19 +81,15 @@ public class SwitchCardPlayerHandler implements ActionHandler {
                 card.convertToJson() + "}";
     }
 
-    public String[][] readInfosFromMessage(JsonNode msg){
-        return new String[0][0];
-    }
+    public int getidofcard(String[] message){
 
-    public int getidofcard(String[] meassage){
-
-        if(meassage[2].equals("null")){
+        if(message[2].equals("null")){
             passiveanswer=1;
-            return Integer.parseInt(meassage[3]);
+            return Integer.parseInt(message[3]);
         }
         else{
             passiveanswer=0;
-            return Integer.parseInt(meassage[2]);
+            return Integer.parseInt(message[2]);
         }
 
     }

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
@@ -42,7 +42,7 @@ public class SwitchCardPlayerHandler implements ActionHandler {
                 if(p.getUsername().equals(switchUsername)){
                     p.getCards().add(currentCard);
                     WebSocketSession switchSession= p.getSession();
-                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findUsernameofPlayer(session))));
+                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findUsernameOfPlayer(session))));
                     break;
                 }
             }

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
@@ -42,7 +42,7 @@ public class SwitchCardPlayerHandler implements ActionHandler {
                 if(p.getUsername().equals(switchUsername)){
                     p.getCards().add(currentCard);
                     WebSocketSession switchSession= p.getSession();
-                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findusernameofPlayer(session))));
+                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findUsernameOfPlayer(session))));
                     break;
                 }
             }

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/SwitchCardPlayerHandler.java
@@ -42,7 +42,7 @@ public class SwitchCardPlayerHandler implements ActionHandler {
                 if(p.getUsername().equals(switchUsername)){
                     p.getCards().add(currentCard);
                     WebSocketSession switchSession= p.getSession();
-                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findusernameofPlayer(session))));
+                    switchSession.sendMessage(new TextMessage(convertToJSONrequest(currentCard, UtilityMethods.findUsernameofPlayer(session))));
                     break;
                 }
             }

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
@@ -1,0 +1,56 @@
+package at.aau.se2.handler.game.subhandlers;
+
+import at.aau.se2.utils.Lobby;
+import at.aau.se2.utils.Player;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+public class TurnHandler implements ActionHandler {
+
+    private static final Logger logger = Logger.getLogger(GameRoundHandler.class.getName());
+    private Lobby lobby;
+    private int currentPlayerIndex = 0;
+
+
+    @Override
+    public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
+        String type = msg.path("type").asText();
+        if ("END_TURN".equals(type)) {
+            endCurrentTurn();
+            startNextTurn();
+            notifyPlayersCurrentTurn();
+
+        }
+    }
+
+    private void endCurrentTurn() {
+        logger.info("Ending turn for player index " + currentPlayerIndex);
+    }
+
+    private void startNextTurn() {
+        currentPlayerIndex = (currentPlayerIndex + 1) % lobby.getPlayers().size();
+    }
+
+    private void notifyPlayersCurrentTurn() {
+        Player currentPlayer = lobby.getPlayers().get(currentPlayerIndex);
+        lobby.getPlayers().forEach(player -> sendMessageToPlayer(player.getSession(), currentPlayer));
+    }
+
+    private void sendMessageToPlayer(WebSocketSession session, Player currentPlayer) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode messageNode = objectMapper.createObjectNode();
+        messageNode.put("type", "CURRENT_PLAYER");
+        messageNode.put("username", currentPlayer.getUsername());
+        try {
+            session.sendMessage(new TextMessage(messageNode.toString()));
+        } catch (IOException e) {
+            logger.severe("Failed to send current player message: " + e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
@@ -12,10 +12,9 @@ import java.io.IOException;
 import java.util.logging.Logger;
 public class TurnHandler implements ActionHandler {
 
-    private static final Logger logger = Logger.getLogger(GameRoundHandler.class.getName());
-    private Lobby lobby;
+    private static final Logger logger = Logger.getLogger(TurnHandler.class.getName());
     private int currentPlayerIndex = 0;
-
+    private int playerCount = 4; // Anzahl der Spieler
 
     @Override
     public void handleMessage(WebSocketSession session, JsonNode msg, Lobby lobby) {
@@ -23,8 +22,7 @@ public class TurnHandler implements ActionHandler {
         if ("END_TURN".equals(type)) {
             endCurrentTurn();
             startNextTurn();
-            notifyPlayersCurrentTurn();
-
+            notifyNextPlayerIndex(session);
         }
     }
 
@@ -33,24 +31,22 @@ public class TurnHandler implements ActionHandler {
     }
 
     private void startNextTurn() {
-        currentPlayerIndex = (currentPlayerIndex + 1) % lobby.getPlayers().size();
+        currentPlayerIndex = (currentPlayerIndex + 1) % playerCount;
     }
 
-    private void notifyPlayersCurrentTurn() {
-        Player currentPlayer = lobby.getPlayers().get(currentPlayerIndex);
-        lobby.getPlayers().forEach(player -> sendMessageToPlayer(player.getSession(), currentPlayer));
-    }
-
-    private void sendMessageToPlayer(WebSocketSession session, Player currentPlayer) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        ObjectNode messageNode = objectMapper.createObjectNode();
-        messageNode.put("type", "CURRENT_PLAYER");
-        messageNode.put("username", currentPlayer.getUsername());
+    private void notifyNextPlayerIndex(WebSocketSession session) {
         try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode messageNode = objectMapper.createObjectNode();
+            String currentPlayerIndexString = String.valueOf(currentPlayerIndex);
+            messageNode.put("type", "CURRENT_PLAYER");
+            messageNode.put("index", currentPlayerIndexString);
             session.sendMessage(new TextMessage(messageNode.toString()));
         } catch (IOException e) {
-            logger.severe("Failed to send current player message: " + e.getMessage());
+            logger.severe("Failed to send next player index: " + e.getMessage());
         }
     }
+
 }
+
 

--- a/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
+++ b/src/main/java/at/aau/se2/handler/game/subhandlers/TurnHandler.java
@@ -22,7 +22,7 @@ public class TurnHandler implements ActionHandler {
         if ("END_TURN".equals(type)) {
             endCurrentTurn();
             startNextTurn();
-            notifyNextPlayerIndex(session);
+            notifyAllPlayers(lobby);
         }
     }
 
@@ -34,19 +34,23 @@ public class TurnHandler implements ActionHandler {
         currentPlayerIndex = (currentPlayerIndex + 1) % playerCount;
     }
 
-    private void notifyNextPlayerIndex(WebSocketSession session) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            ObjectNode messageNode = objectMapper.createObjectNode();
-            String currentPlayerIndexString = String.valueOf(currentPlayerIndex);
-            messageNode.put("type", "CURRENT_PLAYER");
-            messageNode.put("index", currentPlayerIndexString);
-            session.sendMessage(new TextMessage(messageNode.toString()));
-        } catch (IOException e) {
-            logger.severe("Failed to send next player index: " + e.getMessage());
+    private void notifyAllPlayers(Lobby lobby) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode messageNode = objectMapper.createObjectNode();
+        String currentPlayerIndexString = String.valueOf(currentPlayerIndex);
+        messageNode.put("type", "CURRENT_PLAYER");
+        messageNode.put("index", currentPlayerIndexString);
+        String message = messageNode.toString();
+
+        for (Player player : lobby.getPlayers()) {
+            try {
+                player.getSession().sendMessage(new TextMessage(message));
+
+            } catch (IOException e) {
+                logger.severe("Failed to notify player " + ": " + e.getMessage());
+            }
         }
     }
-
 }
 
 

--- a/src/main/java/at/aau/se2/model/Monster.java
+++ b/src/main/java/at/aau/se2/model/Monster.java
@@ -12,8 +12,8 @@ public abstract class Monster extends Tower implements JsonSerializable {
     protected int ring;
     protected Monster(int zone, int ring, int id){
         super(id);
-        this.zone = zone % 4; // 0-3
-        this.ring = ring % 4; // 0-3
+        this.zone = zone;
+        this.ring = ring;
     }
     public int doesDmg(Tower tower){
         if(tower.getLifepoints() >= 1) {

--- a/src/main/java/at/aau/se2/utils/Player.java
+++ b/src/main/java/at/aau/se2/utils/Player.java
@@ -2,30 +2,36 @@ package at.aau.se2.utils;
 
 import at.aau.se2.model.Actioncard;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 public class Player {
     @Getter
     private final Lobby lobby;
+
     @Getter
     private final WebSocketSession session;
+
     @Getter
-    @Setter
     private int points;
+
+    @Getter
     private String username;
-    // TODO username
-//    @Getter
-//    private final String username;
+
+    @Getter
+    private boolean usernameSet;
+
     @Getter
     private final String playerID; // Session ID
+
     @Getter
     private final List<Actioncard> cards;
     public Player(WebSocketSession session, Lobby lobby){
-        //this.username = username;
+        this.username = "";
+        this.usernameSet = false;
         this.playerID = session.getId();
         this.session = session;
         this.lobby = lobby;
@@ -33,20 +39,20 @@ public class Player {
         this.cards = new ArrayList<>();
     }
 
-    public List<Actioncard> getCards() {
-        return cards;
+    public void setPoints(int points){
+        this.points += points;
     }
 
-    public void setusername(String username){
-        this.username = username;
+    public void setUsername(String username){
+        if(!usernameSet){
+            this.username = username;
+            this.usernameSet = true;
+        }
+        else{
+            Logger.getLogger("global")
+                    .info("Username has already been set!");
+        }
     }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public WebSocketSession getSession() {
-        return session;
-    }
 
 }

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/DrawCardHandlerTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/DrawCardHandlerTest.java
@@ -27,7 +27,7 @@ public class DrawCardHandlerTest {
         this.lobby = mock(Lobby.class);
         this.rn = mock(SecureRandom.class);
         this.gs = mock(GameState.class);
-        this.dch = new DrawCardHandler();
+        this.dch = new DrawCardHandler(rn);
     }
 
     @Test

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/DrawCardHandlerTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/DrawCardHandlerTest.java
@@ -1,0 +1,53 @@
+package at.aau.se2.handler.game.subhandlers;
+
+import at.aau.se2.model.characters.Archer;
+import at.aau.se2.model.characters.Fighter;
+import at.aau.se2.model.characters.Hero;
+import at.aau.se2.model.characters.Knight;
+import at.aau.se2.utils.GameState;
+import at.aau.se2.utils.Lobby;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+public class DrawCardHandlerTest {
+    private Lobby lobby;
+    private SecureRandom rn;
+    private GameState gs;
+
+    private DrawCardHandler dch;
+
+    @BeforeEach
+    public void setup(){
+        this.lobby = mock(Lobby.class);
+        this.rn = mock(SecureRandom.class);
+        this.gs = mock(GameState.class);
+        this.dch = new DrawCardHandler();
+    }
+
+    @Test
+    public void testDrawRandomCard(){
+        when(lobby.getGameState()).thenReturn(gs);
+        when(gs.getIndexMinimumCardAmount()).thenReturn(0);
+        when(rn.nextInt(anyInt(), anyInt())).thenReturn(1);
+        assertEquals(Archer.class, dch.drawRandomCard(lobby).getClass());
+        when(gs.getIndexMinimumCardAmount()).thenReturn(1);
+        assertEquals(Fighter.class, dch.drawRandomCard(lobby).getClass());
+        when(gs.getIndexMinimumCardAmount()).thenReturn(2);
+        assertEquals(Knight.class, dch.drawRandomCard(lobby).getClass());
+        when(gs.getIndexMinimumCardAmount()).thenReturn(3);
+        assertEquals(Hero.class, dch.drawRandomCard(lobby).getClass());
+        verify(gs, times(4)).getIndexMinimumCardAmount();
+    }
+
+    @Test
+    public void testConvertToJson(){
+        String exp = "{ 'type' : 'DRAW_CARD', 'id': '1', 'name': 'Bogenschütze', 'zone': '1'}";
+        assertEquals(exp, dch.convertToJson(new Archer(1,1)));
+    }
+}

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/DummyHandlerImplTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/DummyHandlerImplTest.java
@@ -1,4 +1,4 @@
-package at.aau.se2.handler.dummy;
+package at.aau.se2.handler.game.subhandlers;
 
 import at.aau.se2.client.WebSocketClientImpl;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/RequestUsernamesForSwitchHandlerTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/RequestUsernamesForSwitchHandlerTest.java
@@ -1,7 +1,5 @@
-package at.aau.se2.handler.dummy;
+package at.aau.se2.handler.game.subhandlers;
 
-
-import at.aau.se2.handler.game.subhandlers.RequestUsernamesForSwitchHandler;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandlerTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/SpawnMonsterHandlerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.*;
 
 public class SpawnMonsterHandlerTest {
     private Lobby lobby;
+
+    private int zone;
     private SecureRandom rn;
     private SpawnMonsterHandler sph;
     @BeforeEach
@@ -27,11 +29,11 @@ public class SpawnMonsterHandlerTest {
     @Test
     public void testSpawnRandomMonster(){
         when(rn.nextInt(1,3)).thenReturn(1);
-        assertEquals(Slime.class, sph.spawnRandomMonster(lobby).getClass());
+        assertEquals(Slime.class, sph.spawnRandomMonster(1,lobby).getClass());
         when(rn.nextInt(1,3)).thenReturn(2);
-        assertEquals(Sphinx.class, sph.spawnRandomMonster(lobby).getClass());
+        assertEquals(Sphinx.class, sph.spawnRandomMonster(2,lobby).getClass());
         when(rn.nextInt(1,3)).thenReturn(3);
-        assertEquals(Bullrog.class, sph.spawnRandomMonster(lobby).getClass());
+        assertEquals(Bullrog.class, sph.spawnRandomMonster(3,lobby).getClass());
         verify(lobby, times(3)).getGameState();
         verify(rn, times(3)).nextInt(1,3);
     }

--- a/src/test/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandlerTest.java
+++ b/src/test/java/at/aau/se2/handler/game/subhandlers/SwitchCardDeckHandlerTest.java
@@ -1,5 +1,4 @@
-package at.aau.se2.handler.dummy;
-import at.aau.se2.handler.game.subhandlers.SwitchCardDeckHandler;
+package at.aau.se2.handler.game.subhandlers;
 import at.aau.se2.model.characters.Knight;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8,18 +7,26 @@ import net.minidev.json.JSONObject;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+
+import java.security.SecureRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 
 public class SwitchCardDeckHandlerTest {
 
     private SwitchCardDeckHandler test;
 
+    private SecureRandom secureRandom;
+
 
     @BeforeEach
     public void setup(){
-        test = new SwitchCardDeckHandler();
+
+        this.secureRandom = mock(SecureRandom.class);
+        test = new SwitchCardDeckHandler(secureRandom);
     }
 
     @Test

--- a/src/test/java/at/aau/se2/utils/PlayerTest.java
+++ b/src/test/java/at/aau/se2/utils/PlayerTest.java
@@ -1,0 +1,79 @@
+package at.aau.se2.utils;
+
+import at.aau.se2.model.characters.Archer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PlayerTest {
+    private Player player;
+    private Lobby lobby;
+    private WebSocketSession session;
+
+    @BeforeEach
+    public void setup(){
+        session = mock(WebSocketSession.class);
+        lobby = mock(Lobby.class);
+        when(session.getId()).thenReturn("123");
+        player = new Player(session, lobby);
+    }
+
+    @Test
+    public void testGetLobby(){
+        assertEquals(this.lobby, player.getLobby());
+    }
+
+    @Test
+    public void testGetSession(){
+        assertEquals(this.session, player.getSession());
+    }
+
+    @Test
+    public void testGetSetPoints(){
+        assertEquals(0, player.getPoints());
+        player.setPoints(1);
+        assertEquals(1, player.getPoints());
+        player.setPoints(4);
+        assertEquals(5, player.getPoints());
+    }
+
+    @Test
+    public void testGetSetUsername(){
+        assertEquals("", player.getUsername());
+        assertFalse(player.isUsernameSet());
+        player.setUsername("tester");
+        assertTrue(player.isUsernameSet());
+        assertEquals("tester", player.getUsername());
+        player.setUsername("tester2");
+        assertEquals("tester", player.getUsername());
+    }
+
+    @Test
+    public void testGetPlayerID(){
+
+        assertEquals("123", player.getPlayerID());
+    }
+
+    @Test
+    public void testGetCards(){
+        assertTrue(player.getCards().isEmpty());
+        player.getCards().add(mock(Archer.class));
+        assertFalse(player.getCards().isEmpty());
+    }
+
+    @Test
+    public void testConstructor(){
+        assertEquals("", player.getUsername());
+        assertFalse(player.isUsernameSet());
+        assertEquals("123", player.getPlayerID());
+        assertEquals(this.session, player.getSession());
+        assertEquals(this.lobby, player.getLobby());
+        assertEquals(0, player.getPoints());
+        assertTrue(player.getCards().isEmpty());
+    }
+
+}

--- a/src/test/java/at/aau/se2/utils/UtilityMethodsTest.java
+++ b/src/test/java/at/aau/se2/utils/UtilityMethodsTest.java
@@ -1,0 +1,91 @@
+package at.aau.se2.utils;
+
+import at.aau.se2.exceptions.LobbyNotFoundException;
+import at.aau.se2.exceptions.PlayerNotFoundException;
+import at.aau.se2.handler.game.GameHandler;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UtilityMethodsTest {
+
+    private static List<Lobby> lobbies = new ArrayList<>();
+    private static List<Player> players = new ArrayList<>();
+    private static List<WebSocketSession> sessions = new ArrayList<>();
+
+    @BeforeAll
+    public static void setup(){
+        int j = -1;
+        for(int i = 0; i < 12; i++){
+            sessions.add(mock(WebSocketSession.class));
+            if(i % 4 == 0){
+                lobbies.add(mock(Lobby.class));
+                j++;
+            }
+            players.add(mock(Player.class));
+            when(players.get(i).getSession()).thenReturn(sessions.get(i));
+            when(players.get(i).getLobby()).thenReturn(lobbies.get(j));
+            GameHandler.getUsernames().add("User"+i);
+        }
+        when(lobbies.get(0).getPlayers()).thenReturn(players.subList(0, 3));
+        when(lobbies.get(1).getPlayers()).thenReturn(players.subList(4, 7));
+        when(lobbies.get(2).getPlayers()).thenReturn(players.subList(8, 11));
+    }
+    @Test
+    void testFindPlayerInLobby() throws PlayerNotFoundException {
+        assertEquals(players.get(1), UtilityMethods.findPlayer(sessions.get(1), lobbies.get(0)));
+        assertEquals(players.get(6), UtilityMethods.findPlayer(sessions.get(6), lobbies.get(1)));
+        assertEquals(players.get(9), UtilityMethods.findPlayer(sessions.get(9), lobbies.get(2)));
+    }
+
+    @Test
+    void testFindPlayerInLobbyExceptionThrown(){
+        assertThrows(PlayerNotFoundException.class, () -> {
+           UtilityMethods.findPlayer(sessions.get(1), lobbies.get(1));
+        });
+        assertThrows(PlayerNotFoundException.class, () -> {
+           UtilityMethods.findPlayer(mock(WebSocketSession.class), lobbies.get(0));
+        });
+    }
+
+    @Test
+    void testFindPlayerOnServer() throws PlayerNotFoundException{
+        for(int i = 0; i < 12; i++){
+            assertEquals(players.get(i), UtilityMethods.findPlayer(sessions.get(i), players));
+        }
+    }
+
+    @Test
+    void testFindPlayerOnServerExceptionThrown(){
+        assertThrows(PlayerNotFoundException.class, () -> {
+            UtilityMethods.findPlayer(mock(WebSocketSession.class), players);
+        });
+    }
+
+    @Test
+    void testFindLobby() throws LobbyNotFoundException {
+        for(int i = 0; i < 3; i++){
+            assertEquals(lobbies.get(i), UtilityMethods.findLobby(sessions.get(3*(i+1)), players));
+        }
+    }
+
+    @Test
+    void testFindLobbyExceptionThrown(){
+        assertThrows(LobbyNotFoundException.class, () -> {
+           UtilityMethods.findLobby(mock(WebSocketSession.class), players);
+        });
+    }
+
+    @Test
+    void testCheckUsername(){
+        assertTrue(UtilityMethods.checkUsername("User1"));
+        assertFalse(UtilityMethods.checkUsername("username"));
+    }
+}

--- a/src/test/java/at/aau/se2/utils/UtilityMethodsTest.java
+++ b/src/test/java/at/aau/se2/utils/UtilityMethodsTest.java
@@ -16,9 +16,9 @@ import static org.mockito.Mockito.when;
 
 public class UtilityMethodsTest {
 
-    private static List<Lobby> lobbies = new ArrayList<>();
-    private static List<Player> players = new ArrayList<>();
-    private static List<WebSocketSession> sessions = new ArrayList<>();
+    private final static List<Lobby> lobbies = new ArrayList<>();
+    private final static List<Player> players = new ArrayList<>();
+    private final static List<WebSocketSession> sessions = new ArrayList<>();
 
     @BeforeAll
     public static void setup(){
@@ -47,12 +47,8 @@ public class UtilityMethodsTest {
 
     @Test
     void testFindPlayerInLobbyExceptionThrown(){
-        assertThrows(PlayerNotFoundException.class, () -> {
-           UtilityMethods.findPlayer(sessions.get(1), lobbies.get(1));
-        });
-        assertThrows(PlayerNotFoundException.class, () -> {
-           UtilityMethods.findPlayer(mock(WebSocketSession.class), lobbies.get(0));
-        });
+        assertThrows(PlayerNotFoundException.class, () -> UtilityMethods.findPlayer(sessions.get(1), lobbies.get(1)));
+        assertThrows(PlayerNotFoundException.class, () -> UtilityMethods.findPlayer(mock(WebSocketSession.class), lobbies.get(0)));
     }
 
     @Test
@@ -64,9 +60,7 @@ public class UtilityMethodsTest {
 
     @Test
     void testFindPlayerOnServerExceptionThrown(){
-        assertThrows(PlayerNotFoundException.class, () -> {
-            UtilityMethods.findPlayer(mock(WebSocketSession.class), players);
-        });
+        assertThrows(PlayerNotFoundException.class, () -> UtilityMethods.findPlayer(mock(WebSocketSession.class), players));
     }
 
     @Test
@@ -78,9 +72,7 @@ public class UtilityMethodsTest {
 
     @Test
     void testFindLobbyExceptionThrown(){
-        assertThrows(LobbyNotFoundException.class, () -> {
-           UtilityMethods.findLobby(mock(WebSocketSession.class), players);
-        });
+        assertThrows(LobbyNotFoundException.class, () -> UtilityMethods.findLobby(mock(WebSocketSession.class), players));
     }
 
     @Test


### PR DESCRIPTION
Die `SpawnMonsterHandler`-Klasse wurde aktualisiert, um die Zone direkt aus der eingehenden Nachricht zu extrahieren und bei der Monstererzeugung zu verwenden. Diese Änderung erleichtert die clientseitige Implementierung, da alle notwendigen Daten und Informationen in einer einzigen Response zusammengefasst werden, was das Erstellen von `MonsterDTO` Objekten vereinfacht.

Zusätzlich wurden die zugehörigen Tests angepasst, um die korrekte Übergabe und Handhabung der Zone zu überprüfen. Dies stellt sicher, dass die `spawnRandomMonster`-Methode korrekt funktioniert und die Tests unter den neuen Anforderungen erfolgreich durchlaufen werden.

Closes #21 