### PR TITLE
35 hotfix monsterattack

### DIFF
--- a/src/main/java/at/aau/se2/service/MAHService.java
+++ b/src/main/java/at/aau/se2/service/MAHService.java
@@ -7,7 +7,7 @@ import at.aau.se2.model.Tower;
 
 import java.util.List;
 
-import static at.aau.se2.utils.UtilityMethods.logs;
+import static at.aau.se2.utils.UtilityMethods.*;
 
 public class MAHService {
 
@@ -36,11 +36,12 @@ public class MAHService {
                 int attackResult = monster.doesDmg(tower);
                 if (attackResult == 0) {
                     monster.takeDamage(1);
+                    logi("MonsterID " + monsterId + " damaged Tower. MonsterHP: " + monster.getLifepoints() + " TowerHP: " + tower.getLifepoints());
                 } else {
                     logs("Tower could not be damaged. No damage taken by Monster.");
                 }
             } else {
-                logs("Invalid MonsterID or invalid TowerID.");
+                logd("Invalid MonsterID or invalid TowerID.");
             }
         } catch (NumberFormatException e) {
             logs("Error parsing IDs: " + e.getMessage());

--- a/src/main/java/at/aau/se2/utils/GameState.java
+++ b/src/main/java/at/aau/se2/utils/GameState.java
@@ -2,6 +2,7 @@ package at.aau.se2.utils;
 
 import at.aau.se2.model.Monster;
 import at.aau.se2.model.Tower;
+import at.aau.se2.model.towers.TowerImpl;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -16,6 +17,7 @@ public class GameState implements JsonSerializable{
     public GameState(){
         monsters = new ArrayList<>();
         towers = new ArrayList<>();
+        towers.add(new TowerImpl(0));
         cardTypeAmount = new int[4];
         this.round = 0;
     }


### PR DESCRIPTION
**Overview**:

- "towers.add(new TowerImpl(0));" moved to GameState where it belongs.
- In MonsterAttackHandler, the message is now sent to every player in the session, synchronizing monster and tower HP and behavior.
- Added useful debugging in MAHService